### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 RWXGame.py"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The zipped file contains three files:
 - README.md
 - high_scores.txt
 
+## Demo:
+
+[![Run on Repl.it](https://repl.it/badge/github/jleg13/COSC110_Python_assignment)](https://repl.it/github/jleg13/COSC110_Python_assignment)
 
 ## Usage:
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jleg13/COSC110Pythonassignment).